### PR TITLE
Extended `Spark.prototype.reserved.events` with `primus-rooms` events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,17 @@ var debug = require('debug')('primus-rooms:spark')
   , Rooms = require('./rooms');
 
 /**
+ * Reserved events.
+ */
+
+var events = [
+  'joinroom',
+  'leaveallrooms',
+  'leaveroom',
+  'roomserror'
+];
+
+/**
  * Export the `PrimusRooms` method.
  */
 
@@ -167,10 +178,10 @@ function PrimusRooms(primus, options) {
     true : write.call(primus, data);
   };
 
-  // Set reserved events.
+  // Extend the list of the reserved events with `primus-rooms` events
 
   if (primus.reserved) {
-    ['joinroom','leaveallrooms', 'leaveroom', 'roomserror'].forEach(function each(ev) {
+    events.forEach(function each(ev) {
       primus.reserved.events[ev] = 1;
     });
   }
@@ -254,9 +265,18 @@ PrimusRooms.Spark = function RoomsSpark(Spark) {
     };
   });
 
+  // Extend the list of the reserved events with `primus-rooms` events
+
+  if (Spark.prototype.reserved) {
+    events.forEach(function each(ev) {
+      Spark.prototype.reserved.events[ev] = 1;
+    });
+  }
+
   return Spark;
 };
 
-// Expose `Rooms` and `Adapter` 
+// Expose `Rooms`, `Adapter` and reserved events
 PrimusRooms.Rooms = Rooms;
 PrimusRooms.Adapter = Adapter;
+PrimusRooms.events = events;


### PR DESCRIPTION
As discussed in https://github.com/cayasso/primus-emitter/issues/16.
This extends `Spark.prototype.reserved.events` with `joinroom`, `leaveallrooms`, `leaveroom` and `roomserror` events.
