### PR TITLE
Added ability to use numbers as rooms identifiers

### DIFF
--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -58,7 +58,7 @@ Rooms.prototype.bind = function bind() {
 /**
  * Targets a room when broadcasting.
  *
- * @param {String|Array} room
+ * @param {Number|String|Array} room
  * @return {Spark}
  * @api public
  */
@@ -85,7 +85,7 @@ Rooms.prototype.except = function except(ids) {
 /**
  * Joins a room.
  *
- * @param {String|Array} room
+ * @param {Number|String|Array} room
  * @param {Function} fn callback
  * @return {Rooms} this
  * @api public
@@ -118,7 +118,7 @@ Rooms.prototype._join = function _join(room, fn) {
 /**
  * Leaves a room.
  *
- * @param {String|Array} room
+ * @param {Number|String|Array} room
  * @param {Function} fn
  * @return {Rooms} this
  * @api public
@@ -187,7 +187,7 @@ Rooms.prototype.rooms = function rooms(fn) {
 /**
  * Get connected clients.
  *
- * @param {String} room
+ * @param {Number|String} room
  * @param {Function} optional, callback
  * @return {Rooms} this
  * @api public
@@ -214,7 +214,7 @@ Rooms.prototype._clients = function _clients(room, fn) {
  * Empty a room.
  *
  * @param {Spark} spark
- * @param {String|Array} room
+ * @param {Number|String|Array} room
  * @param {Array} sparks
  * @param {Function} fn, callback
  * @return {Primus}
@@ -252,13 +252,14 @@ Rooms.prototype.empty = function empty(room, fn) {
 /**
  * Check if a specific rooms is empty.
  *
- * @param {String} room
+ * @param {Number|String} room
  * @param {Function} fn
  * @return {Rooms} this
  * @api public
  */
 
 Rooms.prototype.isRoomEmpty = function isRoomEmpty(room, fn) {
+  room += '';
   return this.adapter.isEmpty(room, fn);
 };
 
@@ -370,7 +371,7 @@ Rooms.prototype.onend = function onend() {
  * string or array is provided.
  *
  * @param {String} method method to execute
- * @param {String|Array} room
+ * @param {Number|String|Array} room
  * @param {Function} fn, callback
  * @return {Rooms} this
  * @api private
@@ -453,18 +454,19 @@ Object.defineProperty(Rooms.prototype, 'connections', {
       return this[ns];
     },
 
-    set: function set(item) {
-      var i = 0
-        , items = 'string' === typeof item ?
-          item.split(' ') : item;
-      if (isArray(items)) {
-        var len = items.length;
-        for (; i < len; ++i) {
-          item = items[i];
-          if (!~this[ns].indexOf(item)) {
-            this[ns].push(item);
+    set: function set(value) {
+      var values = 'string' === typeof value
+        ? value.split(' ')
+        : 'number' === typeof value
+          ? [value]
+          : value;
+      if (isArray(values)) {
+        values.forEach(function current(val) {
+          val += '';
+          if (!~this[ns].indexOf(val)) {
+            this[ns].push(val);
           }
-        }
+        }, this);
       }
     }
   });
@@ -475,7 +477,7 @@ Object.defineProperty(Rooms.prototype, 'connections', {
  *
  * @param {String} method
  * @param {Spark} spark
- * @param {String|Array} room
+ * @param {Number|String|Array} room
  * @param {Function} fn
  * @return {Rooms} this
  * @api public


### PR DESCRIPTION
This adds the ability to join/target rooms using numbers.
This is done by converting the numbers into strings.
For example:

``` javascript
spark.join(1);
spark.room(1).write('foo');
```

I don't know if it has sense, we can just allow only strings and Array of strings, but the patch was easy enough so here it is.
