### PR TITLE
Removing redundant checks

### DIFF
--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -63,21 +63,7 @@ function Rooms(context, adapter) {
 Rooms.prototype.bind = function bind() {
   if (this.id) {
     this.onend = this.onend.bind(this);
-    this.ctx.on('end', this.onend);
-  }
-  return this;
-};
-
-/**
- * Unbind room events.
- *
- * @return {Rooms} this
- * @api private
- */
-
-Rooms.prototype.unbind = function unbind() {
-  if (this.ctx) {
-    this.ctx.removeListener('end', this.onend);
+    this.ctx.once('end', this.onend);
   }
   return this;
 };
@@ -356,7 +342,7 @@ Rooms.prototype.broadcast = function broadcast(data, method) {
  */
 
 Rooms.prototype.emits = function (ev, data) {
-  if (this.id && this.ctx) {
+  if (this.id) {
     this.ctx.emit(ev, data);
     this.primus.emit(ev, data, this.ctx);
   }
@@ -386,22 +372,14 @@ Rooms.prototype.reset = function reset() {
 
 Rooms.prototype.destroy = function destroy(fn) {
   var rm = this;
-  return this.reset().leaveAll(function remove() {
-
-    // Unbind events if any
-    rm.unbind();
-
+  fn = fn || noop;
+  return this.reset().leaveAll(function cleanup(err) {
     // Delete references
     delete rm.id;
+    delete rm.ctx._rooms;
+    delete rm.ctx;
     delete rm.primus;
-
-    // If still context then remove it
-    if (rm.ctx) {
-      delete rm.ctx._rooms;
-      delete rm.ctx;
-    }
-
-    if (fn) fn(null);
+    fn(err);
   });
 };
 


### PR DESCRIPTION
A new `Rooms` instance should always be created with a valid context (`spark` or `primus`) and we only remove that reference when the `destroy` method completes.
I think that checking for the existence of `ctx` is redundant, but i may miss something here.
