### PR TITLE
Removing `batch` dependency

### DIFF
--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -6,7 +6,7 @@
 
 var debug = require('debug')('primus-rooms:rooms')
   , RoomsError = require('./error')
-  , Batch = require('batch')
+  , async = require('async')
   , isArray = Array.isArray
   , noop = function () {};
 
@@ -100,7 +100,7 @@ Rooms.prototype.in = function target(room) {
  * Set exception ids when brodcasting.
  *
  * @param {String|String[]} ids
- * @return {Rooms} this;
+ * @return {Rooms} this
  * @api public
  */
 
@@ -114,7 +114,7 @@ Rooms.prototype.except = function except(ids) {
  *
  * @param {Number|String|Array<Number|String>} room
  * @param {Function} [fn]
- * @return {Rooms|Object[]}
+ * @return {Rooms} this
  * @api public
  */
 
@@ -147,7 +147,7 @@ Rooms.prototype._join = function _join(room, fn) {
  *
  * @param {Number|String|Array<Number|String>} room
  * @param {Function} [fn]
- * @return {Rooms|Object[]}
+ * @return {Rooms} this
  * @api public
  */
 
@@ -215,7 +215,7 @@ Rooms.prototype.rooms = function rooms(fn) {
  *
  * @param {Number|String|Array<Number|String>} room
  * @param {Function} [fn]
- * @return {Object[]|String[]}
+ * @return {Rooms|String[]}
  * @api public
  */
 
@@ -422,7 +422,7 @@ Rooms.prototype.onend = function onend() {
  * @param {String} method
  * @param {Number|String|Array<Number|String>} [room]
  * @param {Function} [fn]
- * @return {Rooms|Object[]|String[]}
+ * @return {Rooms|String[]}
  * @api private
  */
 
@@ -435,47 +435,25 @@ Rooms.prototype.exec = function exec(method, room, fn) {
 
   if (room) this.__rooms = room;
 
-  var r
-    , re
-    , i = 0
-    , res = []
-    , result = []
-    , rooms = this.__rooms
-    , len = rooms.length;
+  var rooms = this.__rooms
+    , tasks = {}
+    , rm = this;
 
   fn = fn || noop;
 
   this.reset();
 
-  for (; i < len; ++i) {
-    if (1 === len) return this[method](rooms[i], fn);
-    r = rooms[i];
-    re = {};
-    re[r] = this[method](r, cb(r, i));
-    res.push(re);
-  }
+  if (1 === rooms.length) return this[method](rooms[0], fn);
 
-  /**
-   * Handle response.
-   *
-   * @param {String} room
-   * @param {Number} limit
-   * @api private
-   */
-
-  function cb(room, limit) {
-    return function callback(err, res) {
-      if (err) return fn(err, null);
-      re = {};
-      re[room] = res;
-      result.push(re);
-      if (len-1 === limit) {
-        fn(null, result);
-      }
+  rooms.forEach(function (room) {
+    tasks[room] = function (done) {
+      rm[method](room, done);
     };
-  }
+  });
 
-  return res;
+  async.parallel(tasks, fn);
+
+  return this;
 };
 
 /**
@@ -531,17 +509,20 @@ Object.defineProperty(Rooms.prototype, 'connections', {
  */
 
 Rooms.prototype.batch = function batch(method, spark, room, fn) {
-  var rm = this
-    , sparks = isArray(spark) ? spark : [spark]
-    , tasks = new Batch();
+  var sparks = isArray(spark) ? spark : [spark]
+    , tasks = [];
+
+  fn = fn || noop;
 
   sparks.forEach(function each(spark) {
-    if ('string' === typeof spark) spark = rm.connections[spark];
+    if ('string' === typeof spark) spark = this.connections[spark];
     tasks.push(function task(done) {
       spark[method](room, done);
     });
-  });
-  tasks.end(fn);
+  }, this);
+
+  async.parallel(tasks, fn);
+
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "async": "0.9.x",
     "debug": "1.0.x",
-    "batch": "0.5.x",
     "primus-rooms-adapter": "0.2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This takes advantage of `async.parallel` to refactor the `exec` and `batch` methods.
The main advantage is a lot simpler `exec` method.

**Note:** the results returned in the callback have a slightly different structure, so this may include breaking changes.
