### PR TITLE
Prevent closed sparks from joining rooms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,11 @@ sudo: false
 language:
   - node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "iojs"
-  - "4"
+  - "6"
   - "5"
-before_install:
-  - 'if [ "${TRAVIS_NODE_VERSION}" == "0.8" ] ; then npm install -g npm@2.14.14; fi'
+  - "4"
+  - "0.12"
+  - "0.10"
 script:
   - "make test-travis"
 after_script:

--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -6,9 +6,7 @@
 
 var debug = require('debug')('primus-rooms:rooms')
   , parallel = require('async/parallel')
-  , RoomsError = require('./error')
-  , isArray = Array.isArray
-  , noop = function () {};
+  , RoomsError = require('./error');
 
 /**
  * Reserved events.
@@ -20,6 +18,8 @@ var events = [
   'leaveroom',
   'roomserror'
 ];
+
+function noop() {}
 
 /**
  * Expose the `Rooms` constructor.
@@ -37,10 +37,7 @@ module.exports = Rooms;
  */
 
 function Rooms(context, adapter) {
-
-  if (!(this instanceof Rooms)) {
-    return new Rooms(context, adapter);
-  }
+  if (!(this instanceof Rooms)) return new Rooms(context, adapter);
 
   this.ctx = context;
   this.id = this.ctx.id;
@@ -61,10 +58,7 @@ function Rooms(context, adapter) {
  */
 
 Rooms.prototype.bind = function bind() {
-  if (this.id) {
-    this.onend = this.onend.bind(this);
-    this.ctx.once('end', this.onend);
-  }
+  if (this.id) this.ctx.once('end', this.onend.bind(this));
   return this;
 };
 
@@ -245,9 +239,6 @@ Rooms.prototype._clients = function _clients(room, fn) {
  */
 
 Rooms.prototype.empty = function empty(room, fn) {
-
-  var rooms;
-
   if ('function' === typeof room) {
     fn = room;
     room = null;
@@ -259,15 +250,13 @@ Rooms.prototype.empty = function empty(room, fn) {
   if (room) this.__rooms = room;
 
   // Get room
-  rooms = this.__rooms;
+  var rooms = this.__rooms;
 
-  // Reset rooms and expect values
+  // Reset rooms and except values
   this.reset();
 
-  // If no rooms we just clear all
+  // Empty the room or clear everything if no room is specified
   if (!rooms.length) this.adapter.clear(fn);
-
-  // If rooms we empty just that room.
   else this.adapter.empty(rooms, fn);
   return this;
 };
@@ -297,7 +286,7 @@ Rooms.prototype.isRoomEmpty = function isRoomEmpty(room, fn) {
  */
 
 Rooms.prototype.send = function send(ev, data, fn) {
-  var args = [].slice.call(arguments)
+  var args = Array.prototype.slice.call(arguments);
   this.broadcast(args, 'send');
   return this.ctx;
 };
@@ -324,25 +313,23 @@ Rooms.prototype.write = function write(data) {
  */
 
 Rooms.prototype.broadcast = function broadcast(data, method) {
-
   if ('function' === typeof data[data.length - 1]) {
     throw new RoomsError('Callbacks are not supported when broadcasting');
   }
 
   if (this.id) {
-
-    // We need to make sure this is a valid spark and not a destroyed one,
-    // destroyed spark are no longer part of the connection list
-    var conn = this.connections[this.id];
-
-    // If this is not a valid ctx we just ignore the write request
-    if (!conn) return this.reset();
-
+    // Ignore the broadcast request if the spark is closed
+    if (!this.primus.spark(this.id)) return this.reset();
   }
 
-  var options = { rooms: this.__rooms, except: this.__except, method: method, transformer: this.__transformer };
-  this.adapter.broadcast(data, options, this.connections);
+  var options = {
+    except: this.__except,
+    method: method,
+    rooms: this.__rooms,
+    transformer: this.__transformer
+  };
 
+  this.adapter.broadcast(data, options, this.connections);
   return this.reset();
 };
 
@@ -378,35 +365,14 @@ Rooms.prototype.reset = function reset() {
 };
 
 /**
- * `Rooms` destructor.
- *
- * @param {Function} [fn]
- * @return {Rooms} this
- * @api private
- */
-
-Rooms.prototype.destroy = function destroy(fn) {
-  var rm = this;
-  fn = fn || noop;
-  return this.reset().leaveAll(function cleanup(err) {
-    // Delete references
-    delete rm.id;
-    delete rm.ctx._rooms;
-    delete rm.ctx;
-    delete rm.primus;
-    fn(err);
-  });
-};
-
-/**
- * Call the destructor when the `end` event is fired on the spark.
+ * Clean everything when the `end` event is fired on the spark.
  *
  * @return {Rooms} this
  * @api private
  */
 
 Rooms.prototype.onend = function onend() {
-  return this.destroy();
+  return this.reset().leaveAll();
 };
 
 /**
@@ -420,32 +386,29 @@ Rooms.prototype.onend = function onend() {
  */
 
 Rooms.prototype.exec = function exec(method, room, fn) {
-
   if ('function' === typeof room) {
     fn = room;
     room = null;
   }
 
+  fn = fn || noop;
   if (room) this.__rooms = room;
 
   var rooms = this.__rooms
     , tasks = {}
     , rm = this;
 
-  fn = fn || noop;
-
   this.reset();
 
   if (1 === rooms.length) return this[method](rooms[0], fn);
 
-  rooms.forEach(function (room) {
-    tasks[room] = function (done) {
+  rooms.forEach(function each(room) {
+    tasks[room] = function task(done) {
       rm[method](room, done);
     };
   });
 
   parallel(tasks, fn);
-
   return this;
 };
 
@@ -478,7 +441,7 @@ Object.defineProperty(Rooms.prototype, 'connections', {
         : 'number' === typeof value
           ? [value]
           : value;
-      if (isArray(values)) {
+      if (Array.isArray(values)) {
         values.forEach(function current(val) {
           val += '';
           if (!~this[ns].indexOf(val)) {
@@ -502,20 +465,19 @@ Object.defineProperty(Rooms.prototype, 'connections', {
  */
 
 Rooms.prototype.batch = function batch(method, spark, room, fn) {
-  var sparks = isArray(spark) ? spark : [spark]
+  var sparks = Array.isArray(spark) ? spark : [spark]
     , tasks = [];
 
   fn = fn || noop;
 
   sparks.forEach(function each(spark) {
-    if ('string' === typeof spark) spark = this.connections[spark];
+    if ('string' === typeof spark) spark = this.primus.spark(spark);
     tasks.push(function task(done) {
       spark[method](room, done);
     });
   }, this);
 
   parallel(tasks, fn);
-
   return this;
 };
 

--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -127,11 +127,15 @@ Rooms.prototype.join = function join(room, fn) {
 Rooms.prototype._join = function _join(room, fn) {
   var rm = this;
   debug('joining room %s', room);
-  this.adapter.add(this.id, room, function set(err, res) {
-    if (err) return fn(new RoomsError(err, rm.ctx));
-    rm.emits('joinroom', room);
-    fn(null, res);
-  });
+  if (this.primus.spark(this.id)) {
+    this.adapter.add(this.id, room, function set(err, res) {
+      if (err) return fn(new RoomsError(err, rm.ctx));
+      rm.emits('joinroom', room);
+      fn(null, res);
+    });
+  } else {
+    setImmediate(fn, new RoomsError('Spark is closed', this.ctx));
+  }
   return this;
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -1051,22 +1051,6 @@ describe('primus-rooms', function () {
     throw new Error('Test invalidation');
   });
 
-  it('should destroy references to instance', function (done) {
-    primus.on('connection', function (spark) {
-      var rms = spark._rooms;
-      spark._rooms.destroy(function () {
-        expect(spark._rooms).to.be(undefined);
-        expect(rms.primus).to.be(undefined);
-        expect(rms.ctx).to.be(undefined);
-        expect(rms.id).to.be(undefined);
-        spark.removeListener('end', rms.onend);
-        done();
-      });
-    });
-
-    client();
-  });
-
   it('should get all clients connected to a room using primus method', function (done) {
     var ids = [];
 

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,21 @@ describe('primus-rooms', function () {
     client();
   });
 
+  it('should prevent closed sparks from joining rooms', function (done) {
+    primus.on('connection', function (spark) {
+      spark.on('end', function () {
+        spark.join('room1', function (err) {
+          expect(err).to.be.an(Error);
+          expect(err.message).to.be('Spark is closed');
+          done();
+        });
+      });
+      spark.end();
+    });
+
+    client();
+  });
+
   it('should join multiple rooms at once', function (done) {
     primus.on('connection', function (spark) {
       spark.join('room1 room2 room3', function () {


### PR DESCRIPTION
Right now a spark can join a room even if it is already closed and this can create a memory leak as shown in #25.
This patch should fix the issue.