### PR TITLE
Make `join` throw if called synchronously from a closed spark

### DIFF
--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -112,7 +112,10 @@ Rooms.prototype.except = function except(ids) {
  */
 
 Rooms.prototype.join = function join(room, fn) {
-  return this.exec('_join', room, fn);
+  if (this.primus.spark(this.id)) return this.exec('_join', room, fn);
+  var err = new RoomsError('Spark is closed', this.ctx);
+  if (fn) return setImmediate(fn, err), this;
+  throw err;
 };
 
 /**
@@ -127,15 +130,11 @@ Rooms.prototype.join = function join(room, fn) {
 Rooms.prototype._join = function _join(room, fn) {
   var rm = this;
   debug('joining room %s', room);
-  if (this.primus.spark(this.id)) {
-    this.adapter.add(this.id, room, function set(err, res) {
-      if (err) return fn(new RoomsError(err, rm.ctx));
-      rm.emits('joinroom', room);
-      fn(null, res);
-    });
-  } else {
-    setImmediate(fn, new RoomsError('Spark is closed', this.ctx));
-  }
+  this.adapter.add(this.id, room, function set(err, res) {
+    if (err) return fn(new RoomsError(err, rm.ctx));
+    rm.emits('joinroom', room);
+    fn(null, res);
+  });
   return this;
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,10 @@ describe('primus-rooms', function () {
   it('should prevent closed sparks from joining rooms', function (done) {
     primus.on('connection', function (spark) {
       spark.on('end', function () {
+        expect(spark.join.bind(spark, 'room1')).to.throwException(function (err) {
+          expect(err).to.be.an(Error);
+          expect(err.message).to.be('Spark is closed');
+        });
         spark.join('room1', function (err) {
           expect(err).to.be.an(Error);
           expect(err.message).to.be('Spark is closed');


### PR DESCRIPTION
Follow up of #25.
This makes `Rooms#join` throw an error if it is called without a callback and the spark is closed.