### PR TITLE
Update 'debug' module to v2.6.9 re: https://www.npmjs.com/advisories/534

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.0.x",
-    "debug": "2.2.x",
+    "debug": "2.6.9",
     "primus-rooms-adapter": "0.3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,

When installing `primus-rooms`, npm reports the following, due to dependency on `debug 2.2.x`:

```
$ npm init
$ npm install primus-rooms --save
+ primus-rooms@3.4.1
added 7 packages from 7 contributors and audited 7 packages in 0.696s
found 1 low severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details

$ npm audit

                       === npm audit security report ===


                                 Manual Review
             Some vulnerabilities require your attention to resolve

          Visit https://go.npm.me/audit-guide for additional guidance


  Low             Regular Expression Denial of Service

  Package         debug

  Patched in      >= 2.6.9 < 3.0.0 || >= 3.1.0

  Dependency of   primus-rooms

  Path            primus-rooms > debug

  More info       https://npmjs.com/advisories/534

found 1 low severity vulnerability in 7 scanned packages
  1 vulnerability requires manual review. See the full report for details.

$ npm audit fix
up to date in 0.083s
fixed 0 of 1 vulnerability in 7 scanned packages
  1 vulnerability required manual review and could not be updated
```

I bumped `debug` version in `package.json` to `2.6.9` as recommended by the advisory, and the advisory went away, with `primus-rooms` running well so far.